### PR TITLE
rename homeManagerModules to homeModules

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ module.
 ```nix
 { inputs, ... }:
 {
-  imports = [ inputs.snig.homeManagerModules.default ];
+  imports = [ inputs.snig.homeModules.default ];
 }
 ```
 
@@ -65,7 +65,7 @@ highlighting, your Home Manager module would look like this:
 ```nix
 { lib, inputs, ... }:
 {
-  imports = [ inputs.snig.homeManagerModules.configurations.git ];
+  imports = [ inputs.snig.homeModules.configurations.git ];
   programs.git.delta.enable = lib.mkForce false;
 }
 ```

--- a/modules/flake/exports.nix
+++ b/modules/flake/exports.nix
@@ -5,7 +5,7 @@
       default.imports = import ../darwin/module-list.nix;
       configurations = import ../darwin/configurations/modules.nix;
     };
-    homeManagerModules = {
+    homeModules = {
       default.imports = import ../home/module-list.nix;
       configurations = import ../home/configurations/modules.nix;
     };


### PR DESCRIPTION
Closes #24

`homeManagerModules` throws a warning when running `nix flake check`. Renaming to `homeModules` solves the issue, reducing warning output